### PR TITLE
Refactor ETL transformation

### DIFF
--- a/pyspark_etl_project/etl.py
+++ b/pyspark_etl_project/etl.py
@@ -1,48 +1,58 @@
-from pyspark.sql import SparkSession
+from pyspark.sql import SparkSession, DataFrame
 from pyspark.sql.functions import col, current_timestamp, lower, concat_ws, regexp_replace
 
-# Inicializace SparkSession
-spark = SparkSession.builder \
-    .appName("CSV to PostgreSQL ETL") \
-    .config("spark.driver.extraClassPath", "/app/postgresql-42.2.5.jar") \
-    .getOrCreate()
 
-try:
-    # Načtení CSV souboru do DataFrame
-    df = spark.read.csv('/app/data/users.csv', header=True, inferSchema=True)
-
-    # Transformace dat: přidání username, časových razítek a příprava pro import
-    transformed_df = df.select(
+def transform_df(df: DataFrame) -> DataFrame:
+    """Apply ETL transformations to the input DataFrame."""
+    return df.select(
         "first_name",
         "last_name",
         "email",
-        # Vytvoření username z first_name a last_name
-        lower(regexp_replace(concat_ws("_", col("first_name"), col("last_name")), "\\s+", "_")).alias("username"),
+        lower(
+            regexp_replace(
+                concat_ws("_", col("first_name"), col("last_name")), "\\s+", "_"
+            )
+        ).alias("username"),
         current_timestamp().alias("created_at"),
-        current_timestamp().alias("updated_at")
+        current_timestamp().alias("updated_at"),
     )
 
-    # Definice parametrů pro připojení k PostgreSQL
-    db_properties = {
-        "user": "postgres",
-        "password": "postgres",
-        "driver": "org.postgresql.Driver"
-    }
-    db_url = "jdbc:postgresql://postgres:5432/etl_db"
+def main() -> None:
+    """Run the ETL process."""
+    spark = (
+        SparkSession.builder.appName("CSV to PostgreSQL ETL")
+        .config("spark.driver.extraClassPath", "/app/postgresql-42.2.5.jar")
+        .getOrCreate()
+    )
 
-    # Uložení transformovaných dat do PostgreSQL
-    transformed_df.write \
-        .jdbc(url=db_url, 
-              table="users", 
-              mode="append", 
-              properties=db_properties)
+    try:
+        # Načtení CSV souboru do DataFrame
+        df = spark.read.csv("/app/data/users.csv", header=True, inferSchema=True)
 
-    print("Data byla úspěšně načtena do tabulky 'users' v PostgreSQL.")
+        # Aplikace transformací
+        transformed_df = transform_df(df)
 
-except Exception as e:
-    print(f"Chyba při zpracování dat: {str(e)}")
-    raise e
+        # Definice parametrů pro připojení k PostgreSQL
+        db_properties = {
+            "user": "postgres",
+            "password": "postgres",
+            "driver": "org.postgresql.Driver",
+        }
+        db_url = "jdbc:postgresql://postgres:5432/etl_db"
 
-finally:
-    # Ukončení SparkSession
-    spark.stop()
+        # Uložení transformovaných dat do PostgreSQL
+        transformed_df.write.jdbc(
+            url=db_url, table="users", mode="append", properties=db_properties
+        )
+
+        print("Data byla úspěšně načtena do tabulky 'users' v PostgreSQL.")
+    except Exception as e:  # pragma: no cover - logging
+        print(f"Chyba při zpracování dat: {str(e)}")
+        raise e
+    finally:
+        # Ukončení SparkSession
+        spark.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -1,9 +1,10 @@
 import os
 import unittest
 from pyspark.sql import SparkSession
-from pyspark.sql.functions import col
 import tempfile
 import csv
+
+from pyspark_etl_project.etl import transform_df
 
 # Importujeme testovaný kód
 # Pro testy v izolaci bez externích závislostí budeme používat mock data
@@ -43,19 +44,9 @@ class TestETLProcess(unittest.TestCase):
         
     def test_username_transformation(self):
         """Test transformace dat - vytvoření username."""
-        from pyspark.sql.functions import lower, concat_ws, regexp_replace
-        
-        # Načtení dat
         df = self.spark.read.csv(self.temp_csv, header=True, inferSchema=True)
-        
-        # Aplikace transformace
-        transformed_df = df.select(
-            "first_name",
-            "last_name",
-            "email",
-            lower(regexp_replace(concat_ws("_", col("first_name"), col("last_name")), "\\s+", "_")).alias("username")
-        )
-        
+        transformed_df = transform_df(df)
+
         # Ověření vytvoření username
         result = transformed_df.collect()
         self.assertEqual(result[0]["username"], "jan_novák")
@@ -63,20 +54,8 @@ class TestETLProcess(unittest.TestCase):
         
     def test_data_schema(self):
         """Test schématu dat po transformaci."""
-        from pyspark.sql.functions import lower, concat_ws, regexp_replace, current_timestamp
-        
-        # Načtení dat
         df = self.spark.read.csv(self.temp_csv, header=True, inferSchema=True)
-        
-        # Aplikace transformace
-        transformed_df = df.select(
-            "first_name",
-            "last_name",
-            "email",
-            lower(regexp_replace(concat_ws("_", col("first_name"), col("last_name")), "\\s+", "_")).alias("username"),
-            current_timestamp().alias("created_at"),
-            current_timestamp().alias("updated_at")
-        )
+        transformed_df = transform_df(df)
         
         # Ověření schématu
         schema = transformed_df.schema


### PR DESCRIPTION
## Summary
- centralize dataframe transformation in `transform_df`
- update ETL script to call the new function and avoid side effects when imported
- use `transform_df` in the unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyspark')*

------
https://chatgpt.com/codex/tasks/task_e_6843734d213c833082dd7d5e93b97fd3